### PR TITLE
Update verse semantic to poem

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -41,18 +41,18 @@ section[epub|type~="dedication"] blockquote{
 	text-align: initial;
 }
 
-[epub|type~="z3998:verse"] p{
+[epub|type~="z3998:poem"] p{
 	text-align: initial;
 	text-indent: 0;
 }
 
-[epub|type~="z3998:verse"] p > span{
+[epub|type~="z3998:poem"] p > span{
 	display: block;
 	padding-left: 1em;
 	text-indent: -1em;
 }
 
-[epub|type~="z3998:verse"] p > span + br{
+[epub|type~="z3998:poem"] p > span + br{
 	display: none;
 }
 

--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -8,7 +8,7 @@
 	<body epub:type="frontmatter z3998:non-fiction">
 		<section id="dedication" epub:type="dedication">
 			<p>To John Bland</p>
-			<blockquote epub:type="z3998:verse">
+			<blockquote epub:type="z3998:poem">
 				<p>
 					<span>My Lamb, you are so very small,</span>
 					<br/>


### PR DESCRIPTION
According to the SEMoS, z3998:poem is used for entire poems and z3998:verse for fragments. The poem featured in the dedication should be considered complete.